### PR TITLE
Add back symlink for platform specific ts declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export * from './platform-types'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "build": "node ./build.js",
     "generate": "node --experimental-modules ./generator/index.mjs",
     "release": "node ./make-release.js",
-    "all": "npm run generate --docs & npm run build & npm run release"
+    "all": "npm run generate --docs & npm run build & npm run release",
+    "postinstall": "node postInstall.js"
   },
   "devDependencies": {
     "bindings": "^1.5.0",

--- a/postInstall.js
+++ b/postInstall.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const vkversion = '1.1.126';
+
+try {
+  fs.unlinkSync('./platform-types');
+} catch (e) { }
+try {
+  fs.symlinkSync(`./generated/${vkversion}/${process.platform}/`, './platform-types', 'junction');
+} catch (e) { }


### PR DESCRIPTION
This was added before in #45 to solve #36 but then removed in #46
I think this was an error

Also changed the symlink to use `junction` allowing windows to make the symlink without admin rights
It does create a symlink for the entire folder because you cannot link files with `junction`